### PR TITLE
fix: fix a bug when changing block size parameter

### DIFF
--- a/seed_vc/socketio/client.py
+++ b/seed_vc/socketio/client.py
@@ -50,6 +50,7 @@ SAMPLE_RATE = 44100
 CHANNELS = 1
 DTYPE = "int16"
 CHUNK_SIZE = 7938  # Number of frames
+MAX_QUEUE_SIZE = 1  # Maximum queued chunks before draining stale audio
 
 # Global queues and client
 play_q: queue.Queue[bytes] = queue.Queue()  # Server -> Speaker
@@ -129,6 +130,14 @@ def send_loop() -> None:
     """Background thread to send microphone data to server."""
     while True:
         data = send_q.get()
+        if send_q.qsize() > MAX_QUEUE_SIZE:
+            skipped = 0
+            while not send_q.empty():
+                data = send_q.get()
+                skipped += 1
+            logger.warning(
+                "⚠️ Skipped %d stale send chunks to reduce latency", skipped
+            )
         if sio.connected:
             try:
                 logger.debug("📤 Sending audio packet (size: %d bytes)", len(data))
@@ -247,6 +256,15 @@ def main() -> None:
             try:
                 while True:
                     chunk = play_q.get()
+                    if play_q.qsize() > MAX_QUEUE_SIZE:
+                        skipped = 0
+                        while not play_q.empty():
+                            chunk = play_q.get()
+                            skipped += 1
+                        logger.warning(
+                            "⚠️ Skipped %d stale playback chunks to reduce latency",
+                            skipped,
+                        )
                     outstream.write(chunk)
             except KeyboardInterrupt:
                 logger.info("⏹️ Stopped by user")

--- a/seed_vc/socketio/client.py
+++ b/seed_vc/socketio/client.py
@@ -135,9 +135,7 @@ def send_loop() -> None:
             while not send_q.empty():
                 data = send_q.get()
                 skipped += 1
-            logger.warning(
-                "⚠️ Skipped %d stale send chunks to reduce latency", skipped
-            )
+            logger.warning("⚠️ Skipped %d stale send chunks to reduce latency", skipped)
         if sio.connected:
             try:
                 logger.debug("📤 Sending audio packet (size: %d bytes)", len(data))

--- a/seed_vc/socketio/model.py
+++ b/seed_vc/socketio/model.py
@@ -367,6 +367,12 @@ class VoiceConverter:
         else:
             self.resampler2 = None
 
+        # Reset VAD state for new buffer configuration
+        self.vad_cache = {}
+        self.vad_chunk_size = min(500, 1000 * self.block_time)
+        self.vad_speech_detected = False
+        self.set_speech_detected_false_at_end_flag = False
+
     def _load_models(
         self,
     ) -> Tuple[

--- a/seed_vc/socketio/server.py
+++ b/seed_vc/socketio/server.py
@@ -115,13 +115,18 @@ async def connect(
         client_sample_rate = auth.get("sample_rate")
 
         if client_chunk_size is not None and client_sample_rate is not None:
-            # Calculate expected chunk size based on server's block_time
+            # Calculate expected chunk size based on converter's block_frame
+            # Use the same zc-aligned formula as model._init_buffers()
             if global_converter is not None:
                 block_time = global_converter.block_time
+                expected_chunk_size = global_converter.block_frame
             else:
-                # Fallback to default value if converter not yet initialized
+                # Fallback: use zc-aligned formula matching model._init_buffers()
                 block_time = 0.18
-            expected_chunk_size = int(block_time * client_sample_rate)
+                zc = client_sample_rate // 50
+                expected_chunk_size = (
+                    int(np.round(block_time * client_sample_rate / zc)) * zc
+                )
 
             if client_chunk_size != expected_chunk_size:
                 logger.error(

--- a/seed_vc/socketio/server.py
+++ b/seed_vc/socketio/server.py
@@ -124,9 +124,7 @@ async def connect(
                 # Fallback: use zc-aligned formula matching model._init_buffers()
                 block_time = 0.18
                 zc = client_sample_rate // 50
-                expected_chunk_size = (
-                    int(np.round(block_time * client_sample_rate / zc)) * zc
-                )
+                expected_chunk_size = int(np.round(block_time * client_sample_rate / zc)) * zc
 
             if client_chunk_size != expected_chunk_size:
                 logger.error(

--- a/tests/socketio/test_client.py
+++ b/tests/socketio/test_client.py
@@ -1,4 +1,4 @@
-"""Tests for Socket.IO client connection error handling."""
+"""Tests for Socket.IO client connection error handling and queue behavior."""
 
 from unittest.mock import patch
 
@@ -191,3 +191,64 @@ class TestClientConnectionErrors:
         )
         assert client_module.connection_error_details["client_chunk_size"] == 1000
         assert client_module.connection_error_details["expected_chunk_size"] == 7938
+
+
+class TestQueueDraining:
+    """Test cases for queue size limiting to prevent unbounded latency."""
+
+    def setup_method(self):
+        """Clear queues before each test."""
+        while not client_module.play_q.empty():
+            client_module.play_q.get_nowait()
+        while not client_module.send_q.empty():
+            client_module.send_q.get_nowait()
+
+    def test_max_queue_size_constant_exists(self):
+        """Test that MAX_QUEUE_SIZE constant is defined."""
+        assert hasattr(client_module, "MAX_QUEUE_SIZE")
+        assert client_module.MAX_QUEUE_SIZE == 1
+
+    def test_play_queue_drains_stale_chunks(self):
+        """Test that stale chunks are drained when play_q exceeds limit."""
+        # Fill play_q with 5 chunks
+        for i in range(5):
+            client_module.play_q.put(f"chunk_{i}".encode())
+
+        # Simulate consumer: get first, then drain if over limit
+        chunk = client_module.play_q.get()
+        assert client_module.play_q.qsize() > client_module.MAX_QUEUE_SIZE
+
+        skipped = 0
+        while not client_module.play_q.empty():
+            chunk = client_module.play_q.get()
+            skipped += 1
+
+        assert skipped == 4
+        assert chunk == b"chunk_4"
+        assert client_module.play_q.empty()
+
+    def test_send_queue_drains_stale_chunks(self):
+        """Test that stale chunks are drained when send_q exceeds limit."""
+        # Fill send_q with 5 chunks
+        for i in range(5):
+            client_module.send_q.put(f"chunk_{i}".encode())
+
+        # Simulate consumer: get first, then drain if over limit
+        chunk = client_module.send_q.get()
+        assert client_module.send_q.qsize() > client_module.MAX_QUEUE_SIZE
+
+        skipped = 0
+        while not client_module.send_q.empty():
+            chunk = client_module.send_q.get()
+            skipped += 1
+
+        assert skipped == 4
+        assert chunk == b"chunk_4"
+        assert client_module.send_q.empty()
+
+    def test_no_drain_when_queue_within_limit(self):
+        """Test that no draining occurs when queue is within MAX_QUEUE_SIZE."""
+        client_module.play_q.put(b"only_chunk")
+        chunk = client_module.play_q.get()
+        assert client_module.play_q.qsize() <= client_module.MAX_QUEUE_SIZE
+        assert chunk == b"only_chunk"

--- a/tests/socketio/test_model.py
+++ b/tests/socketio/test_model.py
@@ -175,6 +175,35 @@ class TestVoiceConverter:
         # Verify outdata was modified (should not be all zeros)
         assert not np.allclose(outdata, 0)
 
+    @pytest.mark.slow
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU not available")
+    def test_init_buffers_resets_vad_state(self):
+        """Test that _init_buffers resets VAD state when block_time changes."""
+        converter = VoiceConverter(
+            input_sampling_rate=44100,
+            block_time=0.18,
+            diffusion_steps=1,
+        )
+
+        # Simulate stale VAD state from a previous session
+        converter.vad_cache = {"some_key": "stale_value"}
+        converter.vad_speech_detected = True
+        converter.set_speech_detected_false_at_end_flag = True
+        old_vad_chunk_size = converter.vad_chunk_size
+
+        # Change block_time and reinitialize (mimics API parameter update)
+        converter.block_time = 0.12
+        converter._init_buffers()
+
+        # VAD state should be fully reset
+        assert converter.vad_cache == {}
+        assert converter.vad_speech_detected is False
+        assert converter.set_speech_detected_false_at_end_flag is False
+        # vad_chunk_size should be recalculated for new block_time
+        expected_vad_chunk_size = min(500, 1000 * 0.12)  # = 120
+        assert converter.vad_chunk_size == expected_vad_chunk_size
+        assert converter.vad_chunk_size != old_vad_chunk_size
+
     def test_voice_converter_basic_initialization(self):
         """Test basic VoiceConverter initialization without GPU requirements."""
         # Test basic initialization

--- a/tests/socketio/test_server.py
+++ b/tests/socketio/test_server.py
@@ -126,6 +126,7 @@ class TestServerConnectionLimits:
         with patch("seed_vc.socketio.server.MAX_CLIENT", 1):
             mock_converter = MagicMock()
             mock_converter.block_time = 0.18
+            mock_converter.block_frame = 7938
             with patch("seed_vc.socketio.server.global_converter", mock_converter):
                 # Client with invalid chunk size should be rejected
                 auth = {"chunk_size": 1000, "sample_rate": 44100}
@@ -136,7 +137,28 @@ class TestServerConnectionLimits:
                 error_data = exc_info.value.args[0]
                 assert error_data["error"] == ConnectionErrorType.CHUNK_SIZE_MISMATCH.value
                 assert error_data["client_chunk_size"] == 1000
-                assert error_data["expected_chunk_size"] == 7938  # 0.18 * 44100
+                assert error_data["expected_chunk_size"] == 7938
+
+    def test_chunk_size_uses_zc_aligned_block_frame(self):
+        """Test that chunk size validation uses zc-aligned block_frame from converter."""
+        with patch("seed_vc.socketio.server.MAX_CLIENT", 1):
+            mock_converter = MagicMock()
+            mock_converter.block_time = 0.25
+            # zc-aligned: int(round(0.25 * 44100 / 882)) * 882 = round(12.5) * 882 = 10584
+            mock_converter.block_frame = 10584
+            with patch("seed_vc.socketio.server.global_converter", mock_converter):
+                # Client sending zc-aligned chunk size should be accepted
+                auth = {"chunk_size": 10584, "sample_rate": 44100}
+                result = asyncio.run(connect("client_aligned", {}, auth))
+                assert result is True
+                asyncio.run(disconnect("client_aligned"))
+
+                # Client sending simple int(0.25*44100)=11025 should be rejected
+                auth_wrong = {"chunk_size": 11025, "sample_rate": 44100}
+                with pytest.raises(SocketIOConnectionRefused) as exc_info:
+                    asyncio.run(connect("client_wrong", {}, auth_wrong))
+                error_data = exc_info.value.args[0]
+                assert error_data["expected_chunk_size"] == 10584
 
     def test_client_disconnect_reduces_connection_count(self):
         """Test that client disconnection properly reduces the connection count."""


### PR DESCRIPTION
## What?

- Modified to reset VAD status as well as converter buffer when changing parameters.
- Modified to use block size adjust with zc alignment
- Added Queue for client to reduce conversion delay

## Why?

- To fix the issue when changing the `block_size` parameter via API
